### PR TITLE
Switch app.close.io to api.close.com

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 )
 
-const baseURL = "https://app.close.io/api"
+const baseURL = "https://api.close.com/api"
 const version = "v1"
 
 type Closeio struct {


### PR DESCRIPTION
Hey there -- 

Eric here from Close! As part of an ongoing domain migration, we're switching the Base URL of our API to api.close.com. 

This PR makes that change :) 

app.close.io will continue to be supported, but is now deprecated. Thanks! 